### PR TITLE
feat: add refactorex

### DIFF
--- a/packages/refactorex/package.yaml
+++ b/packages/refactorex/package.yaml
@@ -1,0 +1,21 @@
+---
+name: refactorex
+description: Language server allowing for refactoring Elixir code
+homepage: https://github.com/gp-pereira/refactorex
+licenses:
+  - MIT
+languages:
+  - Elixir
+categories:
+  - LSP
+
+source:
+  # renovate:versioning=loose
+  # renovate:datasource=git-refs
+  id: pkg:github/synic/refactorex-mason@main
+  build:
+    run: ./build.sh
+    bin: exec:refactorex-release/bin/start-stdio
+
+bin:
+  refactorex: "{{source.build.bin}}"


### PR DESCRIPTION
## Describe your changes
Add RefactorEx support

[RefactorEx](https://github.com/gp-pereira/refactorex) is an LSP server that allows for refactoring Elixir code. It adds the ability to rename symbols via `vim.lsp.buf.rename()` and various code actions.

Right now it uses an intermediary repository,
https://github.com/synic/refactorex-mason to download the sourcecode, patch it to support the stdio transport, and create a launch script to use the stdio transport. Hopefully in the future this intermediary repository won't be necessary, once refactorex itself supports stdio (https://github.com/gp-pereira/refactorex/pull/19).


## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.